### PR TITLE
Document importing with a dependency manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,21 @@ https://godoc.org/github.com/go-mail/mail
 
 ## Download
 
-    go get gopkg.in/mail.v2
+If you're already using a dependency manager, like [dep][dep], use the following
+import path:
 
+```
+github.com/go-mail/mail
+```
+
+If you *aren't* using vendoring, `go get` the [Gopkg.in](http://gopkg.in)
+import path:
+
+```
+gopkg.in/mail.v2
+```
+
+[dep]: https://github.com/golang/dep#readme
 
 ## Examples
 


### PR DESCRIPTION
@theckman: Thanks for clarifying your stance in ef373989c852ddaa6c5f586c8d988f248ecb7892. I completely agree with you that we should be recommending Gopkg.in only as an alternative to proper dependency management.

This change recommends Gopkg.in as an alternative to using using a dependency manager like dep. Is this more along the lines of what you were thinking?
