### PR TITLE
Adds Message.SetBodyWriter to make templates easy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - #20: Adds `Message.SetBoundary` to allow specifying a custom MIME boundary.
+- #22: Adds `Message.SetBodyWriter` to make it easy to use text/template and
+  html/template for message bodies. Contributed by Quantcast.
 
 ## [2.1.0] - 2017-12-14
 

--- a/example_test.go
+++ b/example_test.go
@@ -194,6 +194,13 @@ func ExampleMessage_SetBody() {
 	m.SetBody("text/plain", "Hello!")
 }
 
+func ExampleMessage_SetBodyWriter() {
+	t := template.Must(template.New("example").Parse("Hello {{.}}!"))
+	m.SetBodyWriter("text/plain", func(w io.Writer) error {
+		return t.Execute(w, "Bob")
+	})
+}
+
 func ExampleMessage_SetDateHeader() {
 	m.SetDateHeader("X-Date", time.Now())
 }

--- a/message.go
+++ b/message.go
@@ -189,9 +189,15 @@ func (m *Message) GetHeader(field string) []string {
 }
 
 // SetBody sets the body of the message. It replaces any content previously set
-// by SetBody, AddAlternative or AddAlternativeWriter.
+// by SetBody, SetBodyWriter, AddAlternative or AddAlternativeWriter.
 func (m *Message) SetBody(contentType, body string, settings ...PartSetting) {
-	m.parts = []*part{m.newPart(contentType, newCopier(body), settings)}
+	m.SetBodyWriter(contentType, newCopier(body), settings...)
+}
+
+// SetBodyWriter sets the body of the message. It can be useful with the
+// text/template or html/template packages.
+func (m *Message) SetBodyWriter(contentType string, f func(io.Writer) error, settings ...PartSetting) {
+	m.parts = []*part{m.newPart(contentType, f, settings)}
 }
 
 // AddAlternative adds an alternative part to the message.
@@ -232,8 +238,8 @@ func (m *Message) newPart(contentType string, f func(io.Writer) error, settings 
 }
 
 // A PartSetting can be used as an argument in Message.SetBody,
-// Message.AddAlternative or Message.AddAlternativeWriter to configure the part
-// added to a message.
+// Message.SetBodyWriter, Message.AddAlternative or Message.AddAlternativeWriter
+// to configure the part added to a message.
 type PartSetting func(*part)
 
 // SetPartEncoding sets the encoding of the part added to the message. By

--- a/message_test.go
+++ b/message_test.go
@@ -236,7 +236,7 @@ func TestBodyWriter(t *testing.T) {
 	m := NewMessage()
 	m.SetHeader("From", "from@example.com")
 	m.SetHeader("To", "to@example.com")
-	m.AddAlternativeWriter("text/plain", func(w io.Writer) error {
+	m.SetBodyWriter("text/plain", func(w io.Writer) error {
 		_, err := w.Write([]byte("Test message"))
 		return err
 	})


### PR DESCRIPTION
Although it's possible to call `Message.AddAlternativeWriter` to an
empty `Message`, there's no easy and obvious way to set the body using
an `io.Writer`. This patch adds `Message.SetBodyWriter` as the obvious
parallel.

Closes go-mail/mail#21.