### PR TITLE
Fix CI example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,7 @@ branches:
 
 notifications:
   email: false
+
+before_install:
+  - mkdir -p $GOPATH/src/gopkg.in &&
+    ln -s ../github.com/go-mail/mail $GOPATH/src/gopkg.in/mail.v2

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ go:
   - 1.7
   - 1.8
   - 1.9
-  - tip
+  - master
 
 # safelist
 branches:


### PR DESCRIPTION
Tests were previously being run against a clone of the v2 branch. This PR fixes the issue by making a symlink to the checkout. While we're at it, we also switch to building against Go `master` instead of `tip`.