### PR TITLE
 Dialer.RequireStartTLS to configure STARTTLS security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - #20: Adds `Message.SetBoundary` to allow specifying a custom MIME boundary.
+- #25: Adds `Dialer.RequireStartTLS` so that `MandatoryStartTLS` can
+  be required, or `NoStartTLS` can disable it. Contributed by Quantcast.
 
 ## [2.1.0] - 2017-12-14
 

--- a/example_test.go
+++ b/example_test.go
@@ -20,6 +20,7 @@ func Example() {
 	m.Attach("/home/Alex/lolcat.jpg")
 
 	d := mail.NewDialer("smtp.example.com", 587, "user", "123456")
+	d.RequireStartTLS = mail.MandatoryStartTLS
 
 	// Send the email to Bob, Cora and Dan.
 	if err := d.DialAndSend(m); err != nil {
@@ -33,6 +34,7 @@ func Example_daemon() {
 
 	go func() {
 		d := mail.NewDialer("smtp.example.com", 587, "user", "123456")
+		d.RequireStartTLS = mail.MandatoryStartTLS
 
 		var s mail.SendCloser
 		var err error
@@ -80,6 +82,7 @@ func Example_newsletter() {
 	}
 
 	d := mail.NewDialer("smtp.example.com", 587, "user", "123456")
+	d.RequireStartTLS = mail.MandatoryStartTLS
 	s, err := d.Dial()
 	if err != nil {
 		panic(err)

--- a/example_test.go
+++ b/example_test.go
@@ -20,7 +20,7 @@ func Example() {
 	m.Attach("/home/Alex/lolcat.jpg")
 
 	d := mail.NewDialer("smtp.example.com", 587, "user", "123456")
-	d.RequireStartTLS = mail.MandatoryStartTLS
+	d.StartTLSPolicy = mail.MandatoryStartTLS
 
 	// Send the email to Bob, Cora and Dan.
 	if err := d.DialAndSend(m); err != nil {
@@ -34,7 +34,7 @@ func Example_daemon() {
 
 	go func() {
 		d := mail.NewDialer("smtp.example.com", 587, "user", "123456")
-		d.RequireStartTLS = mail.MandatoryStartTLS
+		d.StartTLSPolicy = mail.MandatoryStartTLS
 
 		var s mail.SendCloser
 		var err error
@@ -82,7 +82,7 @@ func Example_newsletter() {
 	}
 
 	d := mail.NewDialer("smtp.example.com", 587, "user", "123456")
-	d.RequireStartTLS = mail.MandatoryStartTLS
+	d.StartTLSPolicy = mail.MandatoryStartTLS
 	s, err := d.Dial()
 	if err != nil {
 		panic(err)

--- a/smtp.go
+++ b/smtp.go
@@ -27,7 +27,7 @@ type Dialer struct {
 	// most cases since the authentication mechanism should use the STARTTLS
 	// extension instead.
 	SSL bool
-	// TSLConfig represents the TLS configuration used for the TLS (when the
+	// TLSConfig represents the TLS configuration used for the TLS (when the
 	// STARTTLS extension is used) or SSL connection.
 	TLSConfig *tls.Config
 	// LocalName is the hostname sent to the SMTP server with the HELO command.

--- a/smtp.go
+++ b/smtp.go
@@ -30,14 +30,14 @@ type Dialer struct {
 	// TLSConfig represents the TLS configuration used for the TLS (when the
 	// STARTTLS extension is used) or SSL connection.
 	TLSConfig *tls.Config
-	// RequireStartTLS represents the TLS security level required to
+	// StartTLSPolicy represents the TLS security level required to
 	// communicate with the SMTP server.
 	//
 	// This defaults to OpportunisticStartTLS for backwards compatibility,
 	// but we recommend MandatoryStartTLS for all modern SMTP servers.
 	//
 	// This option has no effect if SSL is set to true.
-	RequireStartTLS StartTLSSecurity
+	StartTLSPolicy StartTLSPolicy
 	// LocalName is the hostname sent to the SMTP server with the HELO command.
 	// By default, "localhost" is sent.
 	LocalName string
@@ -103,9 +103,9 @@ func (d *Dialer) Dial() (SendCloser, error) {
 		}
 	}
 
-	if !d.SSL && d.RequireStartTLS != NoStartTLS {
+	if !d.SSL && d.StartTLSPolicy != NoStartTLS {
 		ok, _ := c.Extension("STARTTLS")
-		if !ok && d.RequireStartTLS == MandatoryStartTLS {
+		if !ok && d.StartTLSPolicy == MandatoryStartTLS {
 			err := fmt.Errorf(
 				"gomail: MandatoryStartTLS required, but " +
 					"SMTP server does not support STARTTLS")
@@ -154,14 +154,14 @@ func (d *Dialer) tlsConfig() *tls.Config {
 	return d.TLSConfig
 }
 
-// Valid values for Dialer.RequireStartTLS.
-type StartTLSSecurity int
+// StartTLSPolicy constants are valid values for Dialer.StartTLSPolicy.
+type StartTLSPolicy int
 
 const (
 	// OpportunisticStartTLS means that SMTP transactions are encrypted if
 	// STARTTLS is supported by the SMTP server. Otherwise, messages are
 	// sent in the clear. This is the default setting.
-	OpportunisticStartTLS StartTLSSecurity = iota
+	OpportunisticStartTLS StartTLSPolicy = iota
 	// MandatoryStartTLS means that SMTP transactions must be encrypted.
 	// SMTP transactions are aborted unless STARTTLS is supported by the
 	// SMTP server.

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -191,6 +191,11 @@ func TestDialerMandatoryStartTLSUnsupported(t *testing.T) {
 		"Extension STARTTLS",
 	})
 
+	if _, ok := err.(StartTLSUnsupportedError); !ok {
+		t.Errorf("expected StartTLSUnsupportedError, but got: %s",
+			reflect.TypeOf(err).Name())
+	}
+
 	expected := "gomail: MandatoryStartTLS required, " +
 		"but SMTP server does not support STARTTLS"
 	if err.Error() != expected {

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -146,10 +146,11 @@ func TestDialerTimeoutNoRetry(t *testing.T) {
 		RetryFailure: false,
 	}
 	testClient := &mockClient{
-		t:       t,
-		addr:    addr(d.Host, d.Port),
-		config:  d.TLSConfig,
-		timeout: true,
+		t:        t,
+		addr:     addr(d.Host, d.Port),
+		config:   d.TLSConfig,
+		startTLS: true,
+		timeout:  true,
 	}
 
 	err := doTestSendMail(t, d, testClient, []string{
@@ -165,12 +166,13 @@ func TestDialerTimeoutNoRetry(t *testing.T) {
 }
 
 type mockClient struct {
-	t       *testing.T
-	i       int
-	want    []string
-	addr    string
-	config  *tls.Config
-	timeout bool
+	t        *testing.T
+	i        int
+	want     []string
+	addr     string
+	config   *tls.Config
+	startTLS bool
+	timeout  bool
 }
 
 func (c *mockClient) Hello(localName string) error {
@@ -180,7 +182,11 @@ func (c *mockClient) Hello(localName string) error {
 
 func (c *mockClient) Extension(ext string) (bool, string) {
 	c.do("Extension " + ext)
-	return true, ""
+	ok := true
+	if ext == "STARTTLS" {
+		ok = c.startTLS
+	}
+	return ok, ""
 }
 
 func (c *mockClient) StartTLS(config *tls.Config) error {
@@ -259,10 +265,11 @@ func (w *mockWriter) Close() error {
 
 func testSendMail(t *testing.T, d *Dialer, want []string) {
 	testClient := &mockClient{
-		t:       t,
-		addr:    addr(d.Host, d.Port),
-		config:  d.TLSConfig,
-		timeout: false,
+		t:        t,
+		addr:     addr(d.Host, d.Port),
+		config:   d.TLSConfig,
+		startTLS: true,
+		timeout:  false,
 	}
 
 	if err := doTestSendMail(t, d, testClient, want); err != nil {
@@ -272,10 +279,11 @@ func testSendMail(t *testing.T, d *Dialer, want []string) {
 
 func testSendMailTimeout(t *testing.T, d *Dialer, want []string) {
 	testClient := &mockClient{
-		t:       t,
-		addr:    addr(d.Host, d.Port),
-		config:  d.TLSConfig,
-		timeout: true,
+		t:        t,
+		addr:     addr(d.Host, d.Port),
+		config:   d.TLSConfig,
+		startTLS: true,
+		timeout:  true,
 	}
 
 	if err := doTestSendMail(t, d, testClient, want); err != nil {

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -97,6 +97,107 @@ func TestDialerSSLConfig(t *testing.T) {
 	})
 }
 
+func TestDialerNoStartTLS(t *testing.T) {
+	d := NewDialer(testHost, testPort, "user", "pwd")
+	d.RequireStartTLS = NoStartTLS
+	testSendMail(t, d, []string{
+		"Extension AUTH",
+		"Auth",
+		"Mail " + testFrom,
+		"Rcpt " + testTo1,
+		"Rcpt " + testTo2,
+		"Data",
+		"Write message",
+		"Close writer",
+		"Quit",
+		"Close",
+	})
+}
+
+func TestDialerOpportunisticStartTLS(t *testing.T) {
+	d := NewDialer(testHost, testPort, "user", "pwd")
+	d.RequireStartTLS = OpportunisticStartTLS
+	testSendMail(t, d, []string{
+		"Extension STARTTLS",
+		"StartTLS",
+		"Extension AUTH",
+		"Auth",
+		"Mail " + testFrom,
+		"Rcpt " + testTo1,
+		"Rcpt " + testTo2,
+		"Data",
+		"Write message",
+		"Close writer",
+		"Quit",
+		"Close",
+	})
+
+	if OpportunisticStartTLS != 0 {
+		t.Errorf("OpportunisticStartTLS: expected 0, got %d",
+			OpportunisticStartTLS)
+	}
+}
+
+func TestDialerOpportunisticStartTLSUnsupported(t *testing.T) {
+	d := NewDialer(testHost, testPort, "user", "pwd")
+	d.RequireStartTLS = OpportunisticStartTLS
+	testSendMailStartTLSUnsupported(t, d, []string{
+		"Extension STARTTLS",
+		"Extension AUTH",
+		"Auth",
+		"Mail " + testFrom,
+		"Rcpt " + testTo1,
+		"Rcpt " + testTo2,
+		"Data",
+		"Write message",
+		"Close writer",
+		"Quit",
+		"Close",
+	})
+}
+
+func TestDialerMandatoryStartTLS(t *testing.T) {
+	d := NewDialer(testHost, testPort, "user", "pwd")
+	d.RequireStartTLS = MandatoryStartTLS
+	testSendMail(t, d, []string{
+		"Extension STARTTLS",
+		"StartTLS",
+		"Extension AUTH",
+		"Auth",
+		"Mail " + testFrom,
+		"Rcpt " + testTo1,
+		"Rcpt " + testTo2,
+		"Data",
+		"Write message",
+		"Close writer",
+		"Quit",
+		"Close",
+	})
+}
+
+func TestDialerMandatoryStartTLSUnsupported(t *testing.T) {
+	d := NewDialer(testHost, testPort, "user", "pwd")
+	d.RequireStartTLS = MandatoryStartTLS
+
+	testClient := &mockClient{
+		t:        t,
+		addr:     addr(d.Host, d.Port),
+		config:   d.TLSConfig,
+		startTLS: false,
+		timeout:  true,
+	}
+
+	err := doTestSendMail(t, d, testClient, []string{
+		"Extension STARTTLS",
+	})
+
+	expected := "gomail: MandatoryStartTLS required, " +
+		"but SMTP server does not support STARTTLS"
+	if err.Error() != expected {
+		t.Errorf("expected %s, but got: %s", expected, err)
+	}
+}
+
 func TestDialerNoAuth(t *testing.T) {
 	d := &Dialer{
 		Host: testHost,
@@ -269,6 +370,20 @@ func testSendMail(t *testing.T, d *Dialer, want []string) {
 		addr:     addr(d.Host, d.Port),
 		config:   d.TLSConfig,
 		startTLS: true,
+		timeout:  false,
+	}
+
+	if err := doTestSendMail(t, d, testClient, want); err != nil {
+		t.Error(err)
+	}
+}
+
+func testSendMailStartTLSUnsupported(t *testing.T, d *Dialer, want []string) {
+	testClient := &mockClient{
+		t:        t,
+		addr:     addr(d.Host, d.Port),
+		config:   d.TLSConfig,
+		startTLS: false,
 		timeout:  false,
 	}
 

--- a/smtp_test.go
+++ b/smtp_test.go
@@ -99,7 +99,7 @@ func TestDialerSSLConfig(t *testing.T) {
 
 func TestDialerNoStartTLS(t *testing.T) {
 	d := NewDialer(testHost, testPort, "user", "pwd")
-	d.RequireStartTLS = NoStartTLS
+	d.StartTLSPolicy = NoStartTLS
 	testSendMail(t, d, []string{
 		"Extension AUTH",
 		"Auth",
@@ -116,7 +116,7 @@ func TestDialerNoStartTLS(t *testing.T) {
 
 func TestDialerOpportunisticStartTLS(t *testing.T) {
 	d := NewDialer(testHost, testPort, "user", "pwd")
-	d.RequireStartTLS = OpportunisticStartTLS
+	d.StartTLSPolicy = OpportunisticStartTLS
 	testSendMail(t, d, []string{
 		"Extension STARTTLS",
 		"StartTLS",
@@ -140,7 +140,7 @@ func TestDialerOpportunisticStartTLS(t *testing.T) {
 
 func TestDialerOpportunisticStartTLSUnsupported(t *testing.T) {
 	d := NewDialer(testHost, testPort, "user", "pwd")
-	d.RequireStartTLS = OpportunisticStartTLS
+	d.StartTLSPolicy = OpportunisticStartTLS
 	testSendMailStartTLSUnsupported(t, d, []string{
 		"Extension STARTTLS",
 		"Extension AUTH",
@@ -158,7 +158,7 @@ func TestDialerOpportunisticStartTLSUnsupported(t *testing.T) {
 
 func TestDialerMandatoryStartTLS(t *testing.T) {
 	d := NewDialer(testHost, testPort, "user", "pwd")
-	d.RequireStartTLS = MandatoryStartTLS
+	d.StartTLSPolicy = MandatoryStartTLS
 	testSendMail(t, d, []string{
 		"Extension STARTTLS",
 		"StartTLS",
@@ -177,7 +177,7 @@ func TestDialerMandatoryStartTLS(t *testing.T) {
 
 func TestDialerMandatoryStartTLSUnsupported(t *testing.T) {
 	d := NewDialer(testHost, testPort, "user", "pwd")
-	d.RequireStartTLS = MandatoryStartTLS
+	d.StartTLSPolicy = MandatoryStartTLS
 
 	testClient := &mockClient{
 		t:        t,


### PR DESCRIPTION
It is possible to use a man-in-the-middle attack to strip STARTTLS security from an SMTP connection. Because all modern SMTP servers support STARTTLS, we recommend that `Dialer.RequireStartTLS` be set to `mail.MandatoryStartTLS`.

For backwards compatibility, this library defaults to `mail.OpportunisticStartTLS`, which means that the client will fallback to a cleartext connection if the SMTP server does not support the STARTTLS extension.

This has no effect on SMTPS connections where TLS wraps the connection itself.

Closes go-mail/mail#23.