### PR TITLE
Fix MIME-Version header field case

### DIFF
--- a/message_test.go
+++ b/message_test.go
@@ -657,7 +657,7 @@ func stubSendMail(t *testing.T, bCount int, want *message) SendFunc {
 			t.Error(err)
 		}
 		got := buf.String()
-		wantMsg := string("Mime-Version: 1.0\r\n" +
+		wantMsg := string("MIME-Version: 1.0\r\n" +
 			"Date: Wed, 25 Jun 2014 17:46:00 +0000\r\n" +
 			want.content)
 		if bCount > 0 {

--- a/send_test.go
+++ b/send_test.go
@@ -15,7 +15,7 @@ const (
 	testBody = "Test message"
 	testMsg  = "To: " + testTo1 + ", " + testTo2 + "\r\n" +
 		"From: " + testFrom + "\r\n" +
-		"Mime-Version: 1.0\r\n" +
+		"MIME-Version: 1.0\r\n" +
 		"Date: Wed, 25 Jun 2014 17:46:00 +0000\r\n" +
 		"Content-Type: text/plain; charset=UTF-8\r\n" +
 		"Content-Transfer-Encoding: quoted-printable\r\n" +

--- a/writeto.go
+++ b/writeto.go
@@ -19,8 +19,8 @@ func (m *Message) WriteTo(w io.Writer) (int64, error) {
 }
 
 func (w *messageWriter) writeMessage(m *Message) {
-	if _, ok := m.header["Mime-Version"]; !ok {
-		w.writeString("Mime-Version: 1.0\r\n")
+	if _, ok := m.header["MIME-Version"]; !ok {
+		w.writeString("MIME-Version: 1.0\r\n")
 	}
 	if _, ok := m.header["Date"]; !ok {
 		w.writeHeader("Date", m.FormatDate(now()))


### PR DESCRIPTION
According to https://www.w3.org/Protocols/rfc1341/3_MIME-Version.html

"Messages composed in accordance with this document MUST include such a
header field, with the following verbatim text: MIME-Version: 1.0"

At least Thunderbird has been observed acting strangely when the field
is not properly cased.