### PR TITLE
Fix writeBody may get panic because of nil w.partWriter

### DIFF
--- a/writeto.go
+++ b/writeto.go
@@ -258,6 +258,10 @@ func (w *messageWriter) writeHeaders(h map[string][]string) {
 }
 
 func (w *messageWriter) writeBody(f func(io.Writer) error, enc Encoding) {
+	if w.err != nil {
+		return
+	}
+
 	var subWriter io.Writer
 	if w.depth == 0 {
 		w.writeString("\r\n")


### PR DESCRIPTION
- If (*messageWriter).createPart fails, w.err will be set and
  w.partWriter will be nil.
- (*messageWriter).writeBody do not check the w.err and the
  w.partWriter. It may try to use the nil w.partWriter, causing
  "panic: runtime error: invalid memory address or nil pointer
  dereference".
- Adding the check of w.err, just like (*messageWriter).Write, do
  nothing in (*messageWriter).writeBody if w.err is not nil.